### PR TITLE
Custom url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,9 +1350,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -1762,9 +1762,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2376,6 +2376,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tokio",
+ "url",
  "which 5.0.0",
 ]
 
@@ -3138,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -4852,9 +4853,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/crates/da-rpc/Cargo.toml
+++ b/crates/da-rpc/Cargo.toml
@@ -10,6 +10,7 @@ eyre        = { workspace = true }
 futures     = { workspace = true }
 log         = { workspace = true }
 tokio       = { version = "1.0", features = [ "full" ] }
+url         = "2.5.0"
 
 # Serialization
 serde      = { workspace = true, default-features = true }

--- a/gopkg/da-rpc/near_test.go
+++ b/gopkg/da-rpc/near_test.go
@@ -64,7 +64,7 @@ func TestNewConfig(t *testing.T) {
 }
 
 func TestNewConfigFile(t *testing.T) {
-	config, err := near.NewConfigFile("keyPath", "contract", "127.0.0.1:3030", 1)
+	config, err := near.NewConfigFile("keyPath", "contract", "http://127.0.0.1:3030", 1)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Apologies that it went through couple iterations, motivation for this is:
We have a use case when we deploy services in containers, hence indexer gets its own IP. At this point communicating with it from da-rpc using 127.0.0.1 fails since it(da-rpc) is deployed in another container - `relayer`. 

This PR intends to address this issue, requiring one to just provide `custom` url to the node. This allows such usages:

http://near-sffl-indexer:3030
http://ip:port