### PR TITLE
fix occasional crash

### DIFF
--- a/gopkg/da-rpc/near.go
+++ b/gopkg/da-rpc/near.go
@@ -247,7 +247,7 @@ func To32Bytes(ptr unsafe.Pointer) []byte {
 	return bytes
 }
 
-func GetDAError() error {
+func GetDAError() (err error) {
 	defer func() {
 		if rErr := recover(); rErr != nil {
 			err = fmt.Errorf("critical error from NEAR DA GetDAError: %v", rErr)

--- a/gopkg/da-rpc/near.go
+++ b/gopkg/da-rpc/near.go
@@ -248,6 +248,12 @@ func To32Bytes(ptr unsafe.Pointer) []byte {
 }
 
 func GetDAError() error {
+	defer func() {
+		if rErr := recover(); rErr != nil {
+			err = fmt.Errorf("critical error from NEAR DA GetDAError: %v", rErr)
+		}
+	}()
+	
 	errData := C.get_error()
 
 	if errData != nil {

--- a/gopkg/da-rpc/near.go
+++ b/gopkg/da-rpc/near.go
@@ -164,17 +164,19 @@ func (config *Config) Submit(candidateHex string, data []byte) ([]byte, error) {
 	defer C.free(unsafe.Pointer(txBytes))
 
 	maybeFrameRef := C.submit_batch(config.Client, candidateHexPtr, (*C.uint8_t)(txBytes), C.size_t(len(data)))
+
+	err := GetDAError()
+	if err != nil {
+		return nil, err
+	}
+
 	log.Info("Submitting to NEAR",
 		"maybeFrameData", maybeFrameRef,
 		"candidate", candidateHex,
 		"namespace", config.Namespace,
 		"txLen", C.size_t(len(data)),
 	)
-	err := GetDAError()
-	if err != nil {
-		return nil, err
-	}
-
+	
 	if maybeFrameRef.len > 1 {
 		// Set the tx data to a frame reference
 		frameData := C.GoBytes(unsafe.Pointer(maybeFrameRef.data), C.int(maybeFrameRef.len))
@@ -247,9 +249,10 @@ func To32Bytes(ptr unsafe.Pointer) []byte {
 
 func GetDAError() error {
 	errData := C.get_error()
-	defer C.free(unsafe.Pointer(errData))
 
 	if errData != nil {
+		defer C.free(unsafe.Pointer(errData))
+
 		errStr := C.GoString(errData)
 		return fmt.Errorf("NEAR DA client %s", errStr)
 	} else {


### PR DESCRIPTION
This PR fixes 2 possible issues
1.  `submit_batch` may fail for 2 reasons, thus causes the return value` maybeFrameRef` to be empty and invalid pointer will be found
 * da key has no permission to submit blobs to the blob store contract
 * da key has no allowance to pay for the gas
 
2. `GetDAError` will free a null pointer when errData is empty