### PR TITLE
fix: Clear error after fetching on Go wrapper

### DIFF
--- a/crates/da-rpc-sys/src/lib.rs
+++ b/crates/da-rpc-sys/src/lib.rs
@@ -363,7 +363,7 @@ pub mod test {
 
         let next_error = unsafe { &*get_error() };
         assert!(!next_error.is_null());
-        unsafe { clear_error(); }
+        clear_error();
         let cleared_error = unsafe { &*get_error() };
         assert!(cleared_error.is_null());
     }

--- a/crates/da-rpc-sys/src/lib.rs
+++ b/crates/da-rpc-sys/src/lib.rs
@@ -351,6 +351,7 @@ pub mod test {
     use std::env;
     use std::ffi::CString;
     use std::str::FromStr;
+    use ffi_helpers::Nullable;
 
     const PREVIOUSLY_SUBMITTED_TX: &str = "4YPsDMPsF35x6eWnBpFqrz1PC36tV3JdWwhTx6ZggEQo";
 

--- a/crates/da-rpc-sys/src/lib.rs
+++ b/crates/da-rpc-sys/src/lib.rs
@@ -361,7 +361,12 @@ pub mod test {
         let err_str = unsafe { CStr::from_ptr(error).to_str().unwrap() };
         println!("{:?}", err_str);
         assert_eq!("test", err_str);
-        //assert!(take_last_error().is_some());
+
+        let next_error = unsafe { &*get_error() };
+        assert!(!next_error.is_null());
+        unsafe { clear_error(); }
+        let cleared_error = unsafe { &*get_error() };
+        assert!(cleared_error.is_null());
     }
 
     fn test_get_client() -> (Client, Config) {

--- a/crates/da-rpc-sys/src/lib.rs
+++ b/crates/da-rpc-sys/src/lib.rs
@@ -46,6 +46,13 @@ pub extern "C" fn get_error() -> *mut c_char {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn clear_error() {
+    if ffi_helpers::error_handling::error_message().is_some() {
+        ffi_helpers::error_handling::clear_last_error();
+    }
+}
+
 /// # Safety
 /// We check if the pointers are null
 #[no_mangle]

--- a/crates/da-rpc-sys/src/lib.rs
+++ b/crates/da-rpc-sys/src/lib.rs
@@ -48,9 +48,7 @@ pub extern "C" fn get_error() -> *mut c_char {
 
 #[no_mangle]
 pub extern "C" fn clear_error() {
-    if ffi_helpers::error_handling::error_message().is_some() {
-        ffi_helpers::error_handling::clear_last_error();
-    }
+    ffi_helpers::error_handling::clear_last_error();
 }
 
 /// # Safety

--- a/crates/da-rpc-sys/src/lib.rs
+++ b/crates/da-rpc-sys/src/lib.rs
@@ -346,10 +346,10 @@ pub mod test {
     use super::*;
     use da_rpc::log::LevelFilter;
     use da_rpc::near::config::Network;
+    use ffi_helpers::Nullable;
     use std::env;
     use std::ffi::CString;
     use std::str::FromStr;
-    use ffi_helpers::Nullable;
 
     const PREVIOUSLY_SUBMITTED_TX: &str = "4YPsDMPsF35x6eWnBpFqrz1PC36tV3JdWwhTx6ZggEQo";
 

--- a/crates/da-rpc-sys/src/lib.rs
+++ b/crates/da-rpc-sys/src/lib.rs
@@ -346,7 +346,6 @@ pub mod test {
     use super::*;
     use da_rpc::log::LevelFilter;
     use da_rpc::near::config::Network;
-    use ffi_helpers::Nullable;
     use std::env;
     use std::ffi::CString;
     use std::str::FromStr;
@@ -361,11 +360,9 @@ pub mod test {
         println!("{:?}", err_str);
         assert_eq!("test", err_str);
 
-        let next_error = unsafe { &*get_error() };
-        assert!(!next_error.is_null());
+        assert!(!get_error().is_null());
         clear_error();
-        let cleared_error = unsafe { &*get_error() };
-        assert!(cleared_error.is_null());
+        assert!(get_error().is_null());
     }
 
     fn test_get_client() -> (Client, Config) {

--- a/gopkg/da-rpc/lib/libnear_da_rpc_sys.h
+++ b/gopkg/da-rpc/lib/libnear_da_rpc_sys.h
@@ -29,6 +29,8 @@ typedef struct RustSafeArray {
 
 char *get_error(void);
 
+void clear_error(void);
+
 /**
  * # Safety
  * We check if the pointers are null

--- a/gopkg/da-rpc/near.go
+++ b/gopkg/da-rpc/near.go
@@ -259,6 +259,8 @@ func GetDAError() (err error) {
 	if errData != nil {
 		defer C.free(unsafe.Pointer(errData))
 
+                C.clear_error()
+		
 		errStr := C.GoString(errData)
 		return fmt.Errorf("NEAR DA client %s", errStr)
 	} else {


### PR DESCRIPTION
This PR makes it so the Go wrapper properly clears  the last error from `ffi_helpers` whenever `GetDAError` is called.