### PR TITLE
chore: fix put route

### DIFF
--- a/bin/sidecar/src/main.rs
+++ b/bin/sidecar/src/main.rs
@@ -219,7 +219,7 @@ async fn main() {
         .route("/blob", routing::get(get))
         .route("/blob", routing::post(submit))
         .route("/plasma/get/:transaction_id", routing::get(plasma::get))
-        .route("/plasma/put", routing::post(plasma::submit))
+        .route("/plasma/put/", routing::post(plasma::submit))
         .with_state(state)
         .layer(
             TraceLayer::new_for_http()


### PR DESCRIPTION
OP sends POST request to `/put/`, impl [here](https://github.com/ethereum-optimism/optimism/blob/69d2d47b0f4ea0a41905b0ef52f3fa343ea7633e/op-plasma/daclient.go#L113)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Nuffle-Labs/data-availability/123)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the route path for the `/plasma/put` endpoint by adding a trailing slash to ensure proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->